### PR TITLE
Catalogs and Pig reference genome

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 0.8.1+
 	* Added MouseGutCatalog module
 	* Added DogGutGeneCatalog module
 	* Added PigGeneCatalog module
+	* Added reference genome for Sus scrofa (pig)
 
 Version 0.8.1 2018-06-05 by luispedro
 	* Update to LTS-11.12 (for faster conduit-algorithms used in collect())

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 0.8.1+
 	* Output FastQ quality graphs as PNGs
 	* Added MouseGutCatalog module
 	* Added DogGutGeneCatalog module
+	* Added PigGeneCatalog module
 
 Version 0.8.1 2018-06-05 by luispedro
 	* Update to LTS-11.12 (for faster conduit-algorithms used in collect())

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 0.8.1+
 	* Add allbest() method to mappedreads
 	* Output FastQ quality graphs as PNGs
 	* Added MouseGutCatalog module
+	* Added DogGutGeneCatalog module
 
 Version 0.8.1 2018-06-05 by luispedro
 	* Update to LTS-11.12 (for faster conduit-algorithms used in collect())

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 0.8.1+
 	* Add allbest() method to mappedreads
 	* Output FastQ quality graphs as PNGs
+	* Added MouseGutCatalog module
 
 Version 0.8.1 2018-06-05 by luispedro
 	* Update to LTS-11.12 (for faster conduit-algorithms used in collect())

--- a/Modules/DogGutGeneCatalog.ngm/0.9/Makefile
+++ b/Modules/DogGutGeneCatalog.ngm/0.9/Makefile
@@ -1,0 +1,11 @@
+VERSION := 0.9
+PACKAGE_CONTENTS := dog.fna dog.functional.map module.yaml
+
+dog-gut-${VERSION}.tar.gz: ${PACKAGE_CONTENTS}
+	tar -cz -f $@ --transform "s#^#Modules/DogGutCatalog/${VERSION}/#" $^
+
+dog.functional.map:
+	curl https://zenodo.org/record/1295720/files/dogs.129.emapper.annotations | grep -v '^# ' > $@
+
+dog.fna:
+	curl https://zenodo.org/record/1198434/files/dogs.129.padded.fna.xz | unxz > $@

--- a/Modules/DogGutGeneCatalog.ngm/0.9/module.yaml
+++ b/Modules/DogGutGeneCatalog.ngm/0.9/module.yaml
@@ -1,0 +1,12 @@
+version: '0.9.0'
+name: 'DogGutCatalog'
+references:
+    -
+        name: 'dog-gut'
+        fasta-file: 'dog.fna'
+        map-file: 'dog.functional.map'
+citation: >
+    Coelho, L. P., Kultima, J. R., Costea, P. I., Fournier, C., Pan, Y.,
+    Czarnecki-Maulden, G., … Bork, P. (2018). Similarity of the dog and human
+    gut microbiomes in gene content and response to diet. Microbiome, 6(1), 72.
+    https://doi.org/10.1186/s40168-018-0450-3

--- a/Modules/MouseGutCatalog.ngm/0.9/Makefile
+++ b/Modules/MouseGutCatalog.ngm/0.9/Makefile
@@ -1,0 +1,11 @@
+VERSION := 0.9
+PACKAGE_CONTENTS := mouse.fna mouse.functional.map module.yaml
+
+mouse-gut-${VERSION}.tar.gz: ${PACKAGE_CONTENTS}
+	tar -cz -f $@ --transform "s#^#Modules/MouseGutCatalog/${VERSION}/#" $^
+
+mouse.functional.map:
+	curl https://zenodo.org/record/1295720/files/mouse_184samples.emapper.annotations | grep -v '^# ' > $@
+
+mouse.fna:
+	curl ftp://penguin.genomics.cn/pub/10.5524/100001_101000/100114/Genecatalog/184sample_2.6M.GeneSet.fa.gz | gunzip > $@

--- a/Modules/MouseGutCatalog.ngm/0.9/module.yaml
+++ b/Modules/MouseGutCatalog.ngm/0.9/module.yaml
@@ -1,0 +1,11 @@
+version: '0.9.0'
+name: 'MouseGutCatalog'
+references:
+    -
+        name: 'mouse-gut'
+        fasta-file: 'mouse.fna'
+        map-file: 'mouse.functional.map'
+citation: >
+    Xiao, L., Feng, Q., Liang, S., Sonne, S. B., Xia, Z., Qiu, X., …
+    Kristiansen, K. (2015). A catalog of the mouse gut metagenome. Nature
+    Biotechnology, 33(10), 1103–1108. https://doi.org/10.1038/nbt.3353

--- a/Modules/PigGeneCatalog.ngm/0.9/Makefile
+++ b/Modules/PigGeneCatalog.ngm/0.9/Makefile
@@ -1,0 +1,11 @@
+VERSION := 0.9
+PACKAGE_CONTENTS := pig.fna pig.functional.map module.yaml
+
+pig-gut-${VERSION}.tar.gz: ${PACKAGE_CONTENTS}
+	tar -cz -f $@ --transform "s#^#Modules/PigGutCatalog/${VERSION}/#" $^
+
+pig.functional.map:
+	curl https://zenodo.org/record/1295720/files/pig_287sample.emapper.annotations | grep -v '^# ' > $@
+
+pig.fna:
+	curl ftp://parrot.genomics.cn/gigadb/pub/10.5524/100001_101000/100187/00.geneset/287sample_7.7M.GeneSet.fa.gz | gunzip > $@ 

--- a/Modules/PigGeneCatalog.ngm/0.9/module.yaml
+++ b/Modules/PigGeneCatalog.ngm/0.9/module.yaml
@@ -1,0 +1,13 @@
+version: '0.9.0'
+name: 'PigGutCatalog'
+references:
+    -
+        name: 'pig-gut'
+        fasta-file: 'pig.fna'
+        map-file: 'pig.functional.map'
+citation: >
+    Xiao, L., Estellé, J., Kiilerich, P., Ramayo-Caldas, Y., Xia, Z., Feng, Q., …
+    Wang, J. (2016). A reference gene catalogue of the pig gut microbiome.
+    Nature Microbiology, 1(12), 1–6.
+    https://doi.org/10.1038/nmicrobiol.2016.161
+

--- a/NGLess/ReferenceDatabases.hs
+++ b/NGLess/ReferenceDatabases.hs
@@ -69,6 +69,7 @@ builtinReferences = [Reference rn (Just alias) (T.concat [rn, "-", T.pack versio
                 , ("rn5", "Rattus_norvegicus_Rnor_5.0")
                 , ("rn6", "Rattus_norvegicus_Rnor_6.0")
                 , ("sacCer3", "Saccharomyces_cerevisiae_R64-1-1")
+                , ("susScr11", "Sus_scrofa.Sscrofa11.1")
                 ]]
 
 

--- a/build-scripts/create-standard-packs.py
+++ b/build-scripts/create-standard-packs.py
@@ -17,6 +17,7 @@ datasets = [
     (90, 'rattus_norvegicus', "Rattus_norvegicus.Rnor_6.0", "rn6"),
     (75, 'rattus_norvegicus', "Rattus_norvegicus.Rnor_5.0", "rn5"),
     (75, 'saccharomyces_cerevisiae', "Saccharomyces_cerevisiae.R64-1-1", "sacCer3"),
+    (90, 'sus_scrofa', "Sus_scrofa.Sscrofa11.1", "susScr11"),
 ]
 
 # NOTE: Ensembl gives the same "release name" to different sub-releases or patches

--- a/docs/sources/Organisms.rst
+++ b/docs/sources/Organisms.rst
@@ -50,6 +50,8 @@ The following table represents organisms provided by default:
 +-----------+-----------------------------+-------------------+---------+
 | sacCer3   | saccharomyces\_cerevisiae   | R64-1-1           | 75      |
 +-----------+-----------------------------+-------------------+---------+
+| susScr11  | sus\_scrofa                 | Sscrofa11.1       | 90      |
++-----------+-----------------------------+-------------------+---------+
 
 These archives are all created using versions 75, 85 and 90 of `Ensembl
 <http://www.ensembl.org/>`__.

--- a/docs/sources/command-line-wrappers.md
+++ b/docs/sources/command-line-wrappers.md
@@ -62,7 +62,7 @@ from within NGLess.
 
     usage: ngless-map.py [-h] -i INPUT [-i2 INPUT_REVERSE] [-s INPUT_SINGLES] -o
                          OUTPUT [--auto-install] [--debug]
-                         (-r {sacCer3,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19} | -f FASTA)
+                         (-r {sacCer3,susScr11,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19} | -f FASTA)
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -77,7 +77,7 @@ from within NGLess.
                             Output file/path for results
       --auto-install        Install NGLess if not found in PATH
       --debug               Prints the payload before submitting to ngless
-      -r {sacCer3,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19}, --reference {sacCer3,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19}
+      -r {sacCer3,susScr11,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19}, --reference {sacCer3,susScr11,ce10,dm3,gg4,canFam2,rn4,bosTau4,mm10,hg19}
                             Map against a builtin reference
       -f FASTA, --fasta FASTA
                             Map against a given fasta file (will be indexed if


### PR DESCRIPTION
Catalogs for mouse, dog and pig.
Pig was not yet in the list of reference genomes.
It's added here under the identifier `susScr11`.

Dog and Mouse catalogs were tested.
Pig was not as ngless didn't yet recognize the `susScr11` identifier and I couldn't compile the changes to a binary compatible with our servers.