### PR TITLE
MIN Fix errors/warnings with RefSeqInfoVector C code

### DIFF
--- a/NGLess/Interpretation/Count/RefSeqInfoVector.h
+++ b/NGLess/Interpretation/Count/RefSeqInfoVector.h
@@ -12,7 +12,7 @@ struct PoolC {
         }
     }
     const char* strdup(const char* input) {
-        const int len = std::strlen(input) + 1;
+        const unsigned int len = std::strlen(input) + 1;
         if (len > block_size) {
             char* n = static_cast<char*>(operator new(len));
             std::strcpy(n, input);
@@ -33,7 +33,7 @@ struct PoolC {
     private:
 
     std::vector<void*> data_;
-    int free_;
+    size_t free_;
 };
 
 
@@ -66,6 +66,6 @@ struct RefSeqInfoVector {
 };
 
 extern "C" {
-    void* rsiv_free(void* p) { delete static_cast<RefSeqInfoVector*>(p); }
+    void rsiv_free(void* p) { delete static_cast<RefSeqInfoVector*>(p); }
 }
 


### PR DESCRIPTION
This seems to be causing problems in https://gitlab.com/ngless/ngless/-/jobs/122904272

Newer versions of GCC being strict about `void*` it seems.

I'm not familiar with Haskell <-> C++ so please review.