### PR TITLE
Added reference to the whats-new section for NGless V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ the directory where you wish to install, default is `/usr/local`):
 - [Frequently Asked Questions (FAQ)](https://ngless.embl.de/faq.html)
 - [ngless mailing list](https://groups.google.com/forum/#!forum/ngless)
 - [What's new log](https://ngless.embl.de/whatsnew.html)
+- [NGless V1.1.0 Release Documentation](https://ngless.embl.de/whatsnew.html#version-1-1-0)
 
 ## Authors
 


### PR DESCRIPTION
With reference to issue #129, I have updated the documentation slightly enough to aptly reflect the what's new section(History) of the Latest Release V1.1.0 documentation.
This would ensure a better continuity to developers who are looking up about the project or looking forward to contributing more.
Meanwhile,
Looking forward to adding more contributions to the documentation itself.