### PR TITLE
Inconsistency in folder naming in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ output of sample test cases.
 
     cd tests
 
-Once in the `test` directory, select any of the test folders to run NGless.
+Once in the `tests` directory, select any of the test folders to run NGless.
 
 For example, here we would run the `regression-fqgz` test:
 


### PR DESCRIPTION
The 'tests' folder has been mentioned as 'test directory' in the documentation.